### PR TITLE
rm default options and ots writer

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -54,7 +54,7 @@ func init() {
 	err := initCmd.RegisterFlagCompletionFunc("vault", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return vaultTypes, cobra.ShellCompDirectiveKeepOrder
 	})
-	initCmd.Flags().BoolVar(&acceptPolyenvDefaults, "accept-default-settings", false, "Accept default settings for polyenv file")
+	// initCmd.Flags().BoolVar(&acceptPolyenvDefaults, "accept-default-settings", false, "Accept default settings for polyenv file")
 	cobra.CheckErr(err)
 	rootCmd.AddCommand(initCmd)
 }
@@ -62,7 +62,7 @@ func init() {
 func initialize(cmd *cobra.Command, args []string) {
 	file := polyenvfile.TuiNewFile(Environment)
 
-	file.TuiAddOpts(nil, acceptPolyenvDefaults)
+	file.TuiAddOpts(nil, true)
 
 	e := file.TuiAddGitIgnore()
 	if e != nil {

--- a/internal/plugin/a_main.go
+++ b/internal/plugin/a_main.go
@@ -41,7 +41,7 @@ var Writers = map[string]func() model.Writer{
 	"stdout":     func() model.Writer { return &StdOutWriter{} },
 	"github-env": func() model.Writer { return &GithubWriter{typ: GithubToEnv} },
 	"github-out": func() model.Writer { return &GithubWriter{typ: GithubToOutput} },
-	"ots":        func() model.Writer { return &OtsWriter{} },
+	// "ots":        func() model.Writer { return &OtsWriter{} },
 }
 
 func init() {


### PR DESCRIPTION
# Pull Request

<!-- First of all, THANK YOU for the contribution. i really appreciate any amount of help you can give to the project :) -->
## Description

<!--
general description of the changes you made.
-->

## Changes

<!-- 
Please provide a general list of your changes. 
Used for the changelog :) it will be added as a changelog file to the pr when you create the PR.
If you dont want to add a changelog (in cases where you bugfixed something currently in dev), just leave this empty.
- Fixed wizard for x 
- Done other thing
  - Done sub of other thing
THIS IS ONLY FOR APP UPDATES
-->
- removed ots writer
- removed default options


## Type of change

<!--add new lines here if you want..-->
- [] Bug fix
- [] QOL change
- [] New feature
- [] Breaking change

## Where

<!--add new lines here if you want..-->
- [] Cli
- [] Vault
- [] CI

## Checklist

- [] My code follows the style guidelines
- [] I have added tests
- [] I have updated the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - The init command no longer supports the --accept-default-settings flag; default settings are applied automatically.
  - The "ots" output writer is no longer available.

- UX
  - Init now proceeds with default polyenv settings without additional prompts.

- Documentation
  - Usage instructions updated to reflect removal of the flag and the "ots" writer.

- Chores
  - Internal registrations adjusted to align with the updated defaults and writer availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->